### PR TITLE
Fix background decorations on zoomed landing page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -4415,12 +4415,12 @@ Updated Hero Section for Pill Layout */
     position: absolute;
     top: 20%;
     left: 20vw;
-    width: 300px;
-    height: 200px;
+    width: 18.75rem;
+    height: 12.5rem;
     background: rgba(0, 0, 0, 0.8);
     border-radius: 50% 30% 70% 40%;
     z-index: -1;
-    filter: blur(40px);
+    filter: blur(2.5rem);
     animation: float 6s ease-in-out infinite;
 }
 
@@ -4429,12 +4429,12 @@ Updated Hero Section for Pill Layout */
     position: absolute;
     top: 80vh;
     right: 20%;
-    width: 200px;
-    height: 150px;
+    width: 12.5rem;
+    height: 9.375rem;
     background: rgba(206, 17, 38, 0.6);
     border-radius: 40% 60% 30% 70%;
     z-index: -1;
-    filter: blur(30px);
+    filter: blur(1.875rem);
     animation: float 8s ease-in-out infinite reverse;
 }
 
@@ -4444,12 +4444,12 @@ Updated Hero Section for Pill Layout */
     position: absolute;
     top: 80vh;
     left: 60%;
-    width: 150px;
-    height: 100px;
+    width: 9.375rem;
+    height: 6.25rem;
     background: rgba(0, 107, 63, 0.4);
     border-radius: 60% 40% 80% 20%;
     z-index: -1;
-    filter: blur(25px);
+    filter: blur(1.5625rem);
     animation: float 10s ease-in-out infinite;
 }
 
@@ -4531,35 +4531,35 @@ Updated Hero Section for Pill Layout */
 .shape {
     position: absolute;
     border-radius: 50% 30% 70% 40%;
-    filter: blur(20px);
+    filter: blur(1.25rem);
     opacity: 0.6;
 }
 
 .shape-1 {
-    width: 120px;
-    height: 80px;
+    width: 7.5rem;
+    height: 5rem;
     background: rgba(0, 107, 63, 0.4);
-    top: -60px;
+    top: -3.75rem;
     right: 0;
     animation: float 7s ease-in-out infinite;
 }
 
 .shape-2 {
-    width: 80px;
-    height: 60px;
+    width: 5rem;
+    height: 3.75rem;
     background: rgba(139, 69, 19, 0.5);
-    top: 20px;
-    right: 40px;
+    top: 1.25rem;
+    right: 2.5rem;
     border-radius: 40% 60% 30% 70%;
     animation: float 9s ease-in-out infinite reverse;
 }
 
 .shape-3 {
-    width: 100px;
-    height: 70px;
+    width: 6.25rem;
+    height: 4.375rem;
     background: rgba(255, 140, 0, 0.4);
-    top: 80px;
-    right: -20px;
+    top: 5rem;
+    right: -1.25rem;
     border-radius: 30% 70% 60% 40%;
     animation: float 11s ease-in-out infinite;
 }


### PR DESCRIPTION
Convert all decorative background shapes from fixed px units to rem units to ensure they scale properly with browser zoom. This fixes the issue where background decorations remained the same size when zooming the page.

Changes:
- Convert .shape base blur: 20px → 1.25rem
- Convert .shape-1, .shape-2, .shape-3 dimensions and positioning to rem
- Convert .hero-section::before dimensions and blur to rem
- Convert .hero-section::after dimensions and blur to rem
- Convert .landing-page::before dimensions and blur to rem

All decorative elements now scale proportionally with page zoom.