### PR TITLE
feat: Add layout design options for Screenshot Frenzy

### DIFF
--- a/app/src/features/designProcess/DesignProcessRoute.tsx
+++ b/app/src/features/designProcess/DesignProcessRoute.tsx
@@ -193,9 +193,12 @@ function AnimatedCommandList({ items }: { items: CommandItem[] }) {
 
 /* ── Main route component ────────────────────── */
 
+export type FrenzyLayoutOption = "bento" | "editorial" | "parallax" | "gallery";
+
 export function DesignProcessRoute() {
   const { theme } = useTheme();
   const isMobile = useIsMobile();
+  const [frenzyLayout, setFrenzyLayout] = useState<FrenzyLayoutOption>("bento");
   useRevealOnView(".dp-reveal");
 
   const heroBgSrc = useMemo(() => {
@@ -258,6 +261,27 @@ export function DesignProcessRoute() {
 
   return (
     <div className="page-content page-content--design-process">
+      {/* ─── DEBUG TOGGLE (For Development) ─── */}
+      <div className="dp-frenzy-toggle-bar">
+        <span>Test Screenshot Frenzy Layout:</span>
+        <button
+          className={frenzyLayout === "bento" ? "is-active" : ""}
+          onClick={() => setFrenzyLayout("bento")}
+        >Bento</button>
+        <button
+          className={frenzyLayout === "editorial" ? "is-active" : ""}
+          onClick={() => setFrenzyLayout("editorial")}
+        >Editorial</button>
+        <button
+          className={frenzyLayout === "parallax" ? "is-active" : ""}
+          onClick={() => setFrenzyLayout("parallax")}
+        >Parallax</button>
+        <button
+          className={frenzyLayout === "gallery" ? "is-active" : ""}
+          onClick={() => setFrenzyLayout("gallery")}
+        >Gallery</button>
+      </div>
+
       {/* ─── 1. HERO ─── */}
       <header className="dp-hero" aria-label="My Design Process hero">
         <PixelImage src={heroBgSrc} grid="8x8" />
@@ -369,85 +393,234 @@ export function DesignProcessRoute() {
             all three filters move into wireframes.
           </p>
 
-          <div className="dp-bento" role="list" aria-label="Screenshot direction cards">
-            <article className="dp-bento-card dp-bento-card--a" role="listitem">
-              <img
-                className="dp-bento-img"
-                src="/designProcess/bento/mood-board.png"
-                alt="Design mood board with color swatches and references"
-                loading="lazy"
-                decoding="async"
-              />
-              <div className="dp-bento-body">
-                <span className="dp-bento-chip">Emotion Bucket</span>
-                <h3>Find the tone before committing to layout.</h3>
-                <p>
-                  Mood, texture, and energy come first so the section feels
-                  right before structure starts to lock in.
-                </p>
-              </div>
-            </article>
+          {frenzyLayout === "bento" && (
+            <div className="dp-bento" role="list" aria-label="Screenshot direction cards">
+              <article className="dp-bento-card dp-bento-card--a" role="listitem">
+                <img
+                  className="dp-bento-img"
+                  src="/designProcess/bento/mood-board.png"
+                  alt="Design mood board with color swatches and references"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div className="dp-bento-body">
+                  <span className="dp-bento-chip">Emotion Bucket</span>
+                  <h3>Find the tone before committing to layout.</h3>
+                  <p>
+                    Mood, texture, and energy come first so the section feels
+                    right before structure starts to lock in.
+                  </p>
+                </div>
+              </article>
 
-            <article className="dp-bento-card dp-bento-card--b" role="listitem">
-              <img
-                className="dp-bento-img"
-                src="/designProcess/bento/wireframe.png"
-                alt="Clean wireframe sketch showing website layout"
-                loading="lazy"
-                decoding="async"
-              />
-              <div className="dp-bento-body">
-                <span className="dp-bento-chip">Direction Signal</span>
-                <h3>Stress-test what should lead the story.</h3>
-                <p>
-                  Headline weight, flow, and hierarchy must feel inevitable at
-                  first glance.
-                </p>
-              </div>
-            </article>
+              <article className="dp-bento-card dp-bento-card--b" role="listitem">
+                <img
+                  className="dp-bento-img"
+                  src="/designProcess/bento/wireframe.png"
+                  alt="Clean wireframe sketch showing website layout"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div className="dp-bento-body">
+                  <span className="dp-bento-chip">Direction Signal</span>
+                  <h3>Stress-test what should lead the story.</h3>
+                  <p>
+                    Headline weight, flow, and hierarchy must feel inevitable at
+                    first glance.
+                  </p>
+                </div>
+              </article>
 
-            <article className="dp-bento-card dp-bento-card--c" role="listitem">
-              <img
-                className="dp-bento-img"
-                src="/designProcess/bento/screenshots.png"
-                alt="Multiple reference designs and browser tabs"
-                loading="lazy"
-                decoding="async"
-              />
-              <div className="dp-bento-body">
-                <span className="dp-bento-chip">Pattern Fit</span>
-                <h3>Borrow proven conversion rhythm, not just style.</h3>
-              </div>
-            </article>
+              <article className="dp-bento-card dp-bento-card--c" role="listitem">
+                <img
+                  className="dp-bento-img"
+                  src="/designProcess/bento/screenshots.png"
+                  alt="Multiple reference designs and browser tabs"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div className="dp-bento-body">
+                  <span className="dp-bento-chip">Pattern Fit</span>
+                  <h3>Borrow proven conversion rhythm, not just style.</h3>
+                </div>
+              </article>
 
-            <article className="dp-bento-card dp-bento-card--d" role="listitem">
-              <img
-                className="dp-bento-img"
-                src="/designProcess/bento/typography.png"
-                alt="Typography exploration on screen"
-                loading="lazy"
-                decoding="async"
-              />
-              <div className="dp-bento-body">
-                <span className="dp-bento-chip">Copy Pulse</span>
-                <h3>Does the message land in under five seconds?</h3>
-              </div>
-            </article>
+              <article className="dp-bento-card dp-bento-card--d" role="listitem">
+                <img
+                  className="dp-bento-img"
+                  src="/designProcess/bento/typography.png"
+                  alt="Typography exploration on screen"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div className="dp-bento-body">
+                  <span className="dp-bento-chip">Copy Pulse</span>
+                  <h3>Does the message land in under five seconds?</h3>
+                </div>
+              </article>
 
-            <article className="dp-bento-card dp-bento-card--e" role="listitem">
-              <img
-                className="dp-bento-img"
-                src="/designProcess/bento/mood-board.png"
-                alt="Curated mood references"
-                loading="lazy"
-                decoding="async"
-              />
-              <div className="dp-bento-body">
-                <span className="dp-bento-chip">Merge Rule</span>
-                <h3>Only the strongest fragments graduate to wireframe.</h3>
+              <article className="dp-bento-card dp-bento-card--e" role="listitem">
+                <img
+                  className="dp-bento-img"
+                  src="/designProcess/bento/mood-board.png"
+                  alt="Curated mood references"
+                  loading="lazy"
+                  decoding="async"
+                />
+                <div className="dp-bento-body">
+                  <span className="dp-bento-chip">Merge Rule</span>
+                  <h3>Only the strongest fragments graduate to wireframe.</h3>
+                </div>
+              </article>
+            </div>
+          )}
+
+          {frenzyLayout === "editorial" && (
+            <div className="dp-editorial" role="list" aria-label="Screenshot direction cards">
+              <article className="dp-editorial-card" role="listitem">
+                <img
+                  src="/designProcess/bento/mood-board.png"
+                  alt="Design mood board"
+                />
+                <div className="dp-editorial-overlay">
+                  <span className="dp-editorial-chip">Emotion Bucket</span>
+                  <h3>Find the tone.</h3>
+                  <p>Mood and texture come first before structure locks in.</p>
+                </div>
+              </article>
+              <article className="dp-editorial-card" role="listitem">
+                <img
+                  src="/designProcess/bento/wireframe.png"
+                  alt="Clean wireframe sketch"
+                />
+                <div className="dp-editorial-overlay">
+                  <span className="dp-editorial-chip">Direction Signal</span>
+                  <h3>Stress-test flow.</h3>
+                  <p>Headline weight must feel inevitable at first glance.</p>
+                </div>
+              </article>
+              <article className="dp-editorial-card" role="listitem">
+                <img
+                  src="/designProcess/bento/screenshots.png"
+                  alt="Multiple reference designs"
+                />
+                <div className="dp-editorial-overlay">
+                  <span className="dp-editorial-chip">Pattern Fit</span>
+                  <h3>Borrow proven rhythm.</h3>
+                </div>
+              </article>
+              <article className="dp-editorial-card" role="listitem">
+                <img
+                  src="/designProcess/bento/typography.png"
+                  alt="Typography exploration"
+                />
+                <div className="dp-editorial-overlay">
+                  <span className="dp-editorial-chip">Copy Pulse</span>
+                  <h3>Clear message.</h3>
+                </div>
+              </article>
+              <article className="dp-editorial-card" role="listitem">
+                <img
+                  src="/designProcess/bento/mood-board.png"
+                  alt="Curated mood references"
+                />
+                <div className="dp-editorial-overlay">
+                  <span className="dp-editorial-chip">Merge Rule</span>
+                  <h3>Strongest fragments.</h3>
+                </div>
+              </article>
+            </div>
+          )}
+
+          {frenzyLayout === "parallax" && (
+            <div className="dp-parallax-container">
+              <div className="dp-parallax-track" role="list" aria-label="Screenshot direction cards">
+                <article className="dp-parallax-card" role="listitem">
+                  <div className="dp-parallax-img-wrap">
+                    <img src="/designProcess/bento/mood-board.png" alt="Mood board" loading="lazy" />
+                  </div>
+                  <div className="dp-parallax-content">
+                    <span className="dp-parallax-chip">Emotion Bucket</span>
+                    <h3>Find the tone before committing to layout.</h3>
+                    <p>Mood, texture, and energy come first so the section feels right before structure starts to lock in.</p>
+                  </div>
+                </article>
+                <article className="dp-parallax-card" role="listitem">
+                  <div className="dp-parallax-img-wrap">
+                    <img src="/designProcess/bento/wireframe.png" alt="Wireframe" loading="lazy" />
+                  </div>
+                  <div className="dp-parallax-content">
+                    <span className="dp-parallax-chip">Direction Signal</span>
+                    <h3>Stress-test what should lead the story.</h3>
+                    <p>Headline weight, flow, and hierarchy must feel inevitable at first glance.</p>
+                  </div>
+                </article>
+                <article className="dp-parallax-card" role="listitem">
+                  <div className="dp-parallax-img-wrap">
+                    <img src="/designProcess/bento/screenshots.png" alt="Screenshots" loading="lazy" />
+                  </div>
+                  <div className="dp-parallax-content">
+                    <span className="dp-parallax-chip">Pattern Fit</span>
+                    <h3>Borrow proven conversion rhythm.</h3>
+                  </div>
+                </article>
+                <article className="dp-parallax-card" role="listitem">
+                  <div className="dp-parallax-img-wrap">
+                    <img src="/designProcess/bento/typography.png" alt="Typography" loading="lazy" />
+                  </div>
+                  <div className="dp-parallax-content">
+                    <span className="dp-parallax-chip">Copy Pulse</span>
+                    <h3>Does the message land fast?</h3>
+                  </div>
+                </article>
               </div>
-            </article>
-          </div>
+            </div>
+          )}
+
+          {frenzyLayout === "gallery" && (
+            <div className="dp-gallery-container" role="list" aria-label="Screenshot direction cards">
+              <article className="dp-gallery-card" role="listitem">
+                <img src="/designProcess/bento/mood-board.png" alt="Mood board" loading="lazy" />
+                <div className="dp-gallery-hover">
+                  <span className="dp-gallery-chip">Emotion Bucket</span>
+                  <h3>Find the tone.</h3>
+                  <p>Mood, texture, and energy come first.</p>
+                </div>
+              </article>
+              <article className="dp-gallery-card" role="listitem">
+                <img src="/designProcess/bento/wireframe.png" alt="Wireframe" loading="lazy" />
+                <div className="dp-gallery-hover">
+                  <span className="dp-gallery-chip">Direction Signal</span>
+                  <h3>Stress-test hierarchy.</h3>
+                  <p>Headline weight must feel inevitable.</p>
+                </div>
+              </article>
+              <article className="dp-gallery-card" role="listitem">
+                <img src="/designProcess/bento/screenshots.png" alt="Screenshots" loading="lazy" />
+                <div className="dp-gallery-hover">
+                  <span className="dp-gallery-chip">Pattern Fit</span>
+                  <h3>Borrow conversion rhythm.</h3>
+                  <p>Don't reinvent structural conventions.</p>
+                </div>
+              </article>
+              <article className="dp-gallery-card" role="listitem">
+                <img src="/designProcess/bento/typography.png" alt="Typography" loading="lazy" />
+                <div className="dp-gallery-hover">
+                  <span className="dp-gallery-chip">Copy Pulse</span>
+                  <h3>Readability is king.</h3>
+                  <p>Land the message in under 5 seconds.</p>
+                </div>
+              </article>
+              <article className="dp-gallery-card" role="listitem">
+                <img src="/designProcess/bento/mood-board.png" alt="Mood board" loading="lazy" />
+                <div className="dp-gallery-hover">
+                  <span className="dp-gallery-chip">Merge Rule</span>
+                  <h3>Graduate to wireframe.</h3>
+                  <p>Only the strongest fragments survive.</p>
+                </div>
+              </article>
+            </div>
+          )}
         </div>
       </section>
 

--- a/app/src/features/designProcess/designProcess.css
+++ b/app/src/features/designProcess/designProcess.css
@@ -73,6 +73,53 @@
 }
 
 /* ------------------------------------------------
+   Debug Toggle (For Screenshot Frenzy)
+   ------------------------------------------------ */
+.dp-frenzy-toggle-bar {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(8px);
+  border-radius: 999px;
+  z-index: 9999;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  color: white;
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 0.8rem;
+}
+
+.dp-frenzy-toggle-bar span {
+  margin-right: 0.5rem;
+  opacity: 0.8;
+}
+
+.dp-frenzy-toggle-bar button {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: all 0.2s;
+}
+
+.dp-frenzy-toggle-bar button:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.dp-frenzy-toggle-bar button.is-active {
+  background: white;
+  color: black;
+}
+
+/* ------------------------------------------------
    1. Hero — SVG background with text overlay
    ------------------------------------------------ */
 .dp-hero {
@@ -376,6 +423,307 @@
   font-size: 0.9rem;
   line-height: 1.5;
   color: var(--muted);
+}
+
+/* ------------------------------------------------
+   4B. Screenshot Frenzy — Editorial Spread
+   ------------------------------------------------ */
+.dp-editorial {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 500px;
+  margin-top: 3rem;
+  perspective: 1200px;
+}
+
+.dp-editorial-card {
+  position: absolute;
+  width: min(320px, 60vw);
+  height: min(400px, 75vw);
+  border-radius: 4px;
+  background: #fff;
+  padding: 10px 10px 60px 10px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+  transition: all 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transform-origin: center center;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+:root[data-theme="dark"] .dp-editorial-card {
+  background: #222;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.6);
+}
+
+/* Fan out the cards */
+.dp-editorial-card:nth-child(1) { transform: rotate(-15deg) translateX(-140px) translateY(20px); z-index: 1; }
+.dp-editorial-card:nth-child(2) { transform: rotate(-5deg) translateX(-70px) translateY(-10px); z-index: 2; }
+.dp-editorial-card:nth-child(3) { transform: rotate(2deg) translateX(0) translateY(-20px); z-index: 3; }
+.dp-editorial-card:nth-child(4) { transform: rotate(8deg) translateX(80px) translateY(-5px); z-index: 2; }
+.dp-editorial-card:nth-child(5) { transform: rotate(18deg) translateX(150px) translateY(25px); z-index: 1; }
+
+.dp-editorial-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: 2px;
+  filter: sepia(0.2) contrast(0.9);
+  transition: filter 0.4s ease;
+}
+
+.dp-editorial-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.9) 0%, rgba(0,0,0,0.4) 50%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.5rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.3s ease;
+}
+
+.dp-editorial-chip {
+  align-self: flex-start;
+  padding: 0.2rem 0.6rem;
+  background: var(--kenyan-green);
+  color: white;
+  font-size: 0.7rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.dp-editorial-overlay h3 {
+  color: white;
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  font-family: "Organical", serif;
+}
+
+.dp-editorial-overlay p {
+  color: rgba(255,255,255,0.8);
+  font-size: 0.9rem;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.dp-editorial-card:hover {
+  transform: scale(1.1) translateY(-30px) rotate(0deg) !important;
+  z-index: 10;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.3);
+}
+
+.dp-editorial-card:hover img {
+  filter: sepia(0) contrast(1);
+}
+
+.dp-editorial-card:hover .dp-editorial-overlay {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ------------------------------------------------
+   4C. Screenshot Frenzy — Parallax Filmstrip
+   ------------------------------------------------ */
+.dp-parallax-container {
+  margin-top: 3rem;
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 2rem;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+
+.dp-parallax-container::-webkit-scrollbar {
+  display: none;
+}
+
+.dp-parallax-track {
+  display: flex;
+  gap: 2rem;
+  padding: 0 max(2rem, calc((100vw - min(72ch, calc(100% - 3rem))) / 2));
+  width: max-content;
+}
+
+.dp-parallax-card {
+  width: min(80vw, 600px);
+  scroll-snap-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  opacity: 0.7;
+  transform: scale(0.95);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.dp-parallax-card:hover {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.dp-parallax-img-wrap {
+  width: 100%;
+  height: clamp(250px, 40vh, 400px);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 15px 35px rgba(0,0,0,0.1);
+}
+
+:root[data-theme="dark"] .dp-parallax-img-wrap {
+  box-shadow: 0 15px 35px rgba(0,0,0,0.4);
+}
+
+.dp-parallax-img-wrap img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.dp-parallax-card:hover .dp-parallax-img-wrap img {
+  transform: scale(1.05);
+}
+
+.dp-parallax-content {
+  padding: 0 1rem;
+}
+
+.dp-parallax-chip {
+  display: inline-block;
+  padding: 0.3rem 0.8rem;
+  background: var(--kenyan-green);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+}
+
+.dp-parallax-content h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.dp-parallax-content p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+/* ------------------------------------------------
+   4D. Screenshot Frenzy — Focus Gallery
+   ------------------------------------------------ */
+.dp-gallery-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-auto-rows: 240px;
+  gap: 10px;
+  margin-top: 3rem;
+  padding: 10px;
+  background: var(--surface);
+  border-radius: 12px;
+}
+
+.dp-gallery-container:hover .dp-gallery-card:not(:hover) {
+  opacity: 0.4;
+  filter: grayscale(0.8);
+}
+
+.dp-gallery-card {
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: all 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.dp-gallery-card:nth-child(1) { grid-row: span 2; }
+.dp-gallery-card:nth-child(4) { grid-column: span 2; }
+
+.dp-gallery-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.dp-gallery-card:hover img {
+  transform: scale(1.1);
+}
+
+.dp-gallery-hover {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 2rem;
+  opacity: 0;
+  backdrop-filter: blur(4px);
+  transition: opacity 0.3s ease;
+}
+
+.dp-gallery-card:hover .dp-gallery-hover {
+  opacity: 1;
+}
+
+.dp-gallery-chip {
+  padding: 0.3rem 0.8rem;
+  background: var(--kenyan-green);
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+  transform: translateY(10px);
+  transition: transform 0.4s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.dp-gallery-hover h3 {
+  color: white;
+  margin: 0 0 0.5rem;
+  font-size: 1.4rem;
+  transform: translateY(10px);
+  transition: transform 0.4s cubic-bezier(0.2, 0.8, 0.2, 1) 0.05s;
+}
+
+.dp-gallery-hover p {
+  color: rgba(255,255,255,0.8);
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  transform: translateY(10px);
+  transition: transform 0.4s cubic-bezier(0.2, 0.8, 0.2, 1) 0.1s;
+}
+
+.dp-gallery-card:hover .dp-gallery-chip,
+.dp-gallery-card:hover h3,
+.dp-gallery-card:hover p {
+  transform: translateY(0);
 }
 
 /* ------------------------------------------------


### PR DESCRIPTION
Implement three alternative layout designs (Editorial Spread, Parallax Filmstrip, and Focus Gallery) alongside the original Bento layout for the "Screenshot Frenzy" section on the Design Process page. Added a fixed bottom debug toggle UI to easily switch between the layouts for side-by-side comparison.

---
*PR created automatically by Jules for task [6698212788756108142](https://jules.google.com/task/6698212788756108142) started by @leon-madara*