### PR TITLE
fix(hero): make gradient visible on morphing text spans

### DIFF
--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1063,6 +1063,17 @@ theme-toggle-landscape.react-theme-toggle {
   opacity: 0;
 }
 
+/* When morphing text sits inside a gradient-text parent, the absolutely
+   positioned spans need their own background-clip so the gradient renders
+   through each span's text (background-clip: text on the parent does not
+   reach into absolutely-positioned children). */
+.kenyan-gradient .morphing-text__text {
+  background: inherit;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 .morphing-text__probe {
   position: static;
   display: block;


### PR DESCRIPTION
## Problem

The role morphing text on the hero section was completely invisible on the live site.

**Root cause — two interacting CSS issues:**

1. `.morphing-text__text` spans are `position: absolute`, which takes them out of the h2's inline formatting context. This means `background-clip: text` on the parent `.kenyan-gradient` h2 never clips through to the spans — the gradient had nothing to paint on.

2. The spans had `color: inherit` (inheriting `color: transparent` from `.kenyan-gradient`) and `-webkit-text-fill-color: currentColor`, which resolved to `transparent`. So the text fill was transparent with no gradient behind it → words were invisible.

## Fix

Added a single targeted rule in `global.css`:

```css
.kenyan-gradient .morphing-text__text {
  background: inherit;
  background-clip: text;
  -webkit-background-clip: text;
  -webkit-text-fill-color: transparent;
}
```

Each span now paints the inherited gradient clipped to its own text, making the words visible. `background: inherit` automatically picks up both light and dark theme gradient variants from the parent.

## Test plan

- [ ] Visit https://my-website-9fg.pages.dev/ after deployment and confirm all four role titles cycle through visibly with the Kenyan-flag gradient colours
- [ ] Check dark mode — gradient should switch to the dark variant
- [ ] All 5 `RoleSequence` tests pass (`npm run react:test`)
- [ ] TypeScript: no errors (`npm run react:typecheck`)

https://claude.ai/code/session_01SdqWgAfBVRR2xwUtfcz9Nv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdqWgAfBVRR2xwUtfcz9Nv)_