### PR TITLE
fix(hero): widen role-sequence to fit on a single line

### DIFF
--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1083,6 +1083,19 @@ theme-toggle-landscape.react-theme-toggle {
   pointer-events: none;
 }
 
+/* Role sequence breaks out of the 690px hero-content column so the text
+   fits on a single line. The negative margin centres the overhang equally
+   on both sides. On narrow viewports the min() collapses to the available
+   width so there is no overflow. */
+.role-sequence {
+  width: min(940px, calc(100vw - 4rem));
+  margin-inline: calc((100% - min(940px, calc(100vw - 4rem))) / 2);
+}
+
+.role-sequence .morphing-text__text {
+  white-space: nowrap;
+}
+
 .morphing-text.morphing-text--reduced-motion {
   filter: none;
 }

--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1063,6 +1063,17 @@ theme-toggle-landscape.react-theme-toggle {
   opacity: 0;
 }
 
+/* When morphing text sits inside a gradient-text parent, the absolutely
+   positioned spans need their own background-clip so the gradient renders
+   through each span's text (background-clip: text on the parent does not
+   reach into absolutely-positioned children). */
+.kenyan-gradient .morphing-text__text {
+  background: inherit;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
 .morphing-text__probe {
   position: static;
   display: block;


### PR DESCRIPTION
## Summary

- The hero-content column is capped at `min(690px, calc(100vw - 4rem))`, which is too narrow for "Full Stack AI Developer & Designer" at `2.8rem` — causing it to wrap onto a second line
- Added a `.role-sequence` rule that widens the element to `min(940px, calc(100vw - 4rem))` and uses `margin-inline: calc((100% - min(940px, ...)) / 2)` to break out of the parent symmetrically (≈ −125px per side on desktop)
- Added `white-space: nowrap` on the text spans to lock the text to one line
- On narrow viewports the `min()` collapses to the available width so there is no overflow

## Test plan

- [ ] Visit the preview deployment and confirm all four role titles appear on a single line in the hero
- [ ] Confirm the block visibly extends further left and right than the description text below it
- [ ] Resize the browser down — text should wrap gracefully on smaller screens rather than overflow
- [ ] Dark mode: gradient still renders correctly on the wider spans

https://claude.ai/code/session_01SdqWgAfBVRR2xwUtfcz9Nv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdqWgAfBVRR2xwUtfcz9Nv)_