### PR TITLE
fix(hero): apply SVG threshold filter for liquid morphing effect

### DIFF
--- a/app/src/styles/global.css
+++ b/app/src/styles/global.css
@@ -1027,7 +1027,7 @@ theme-toggle-landscape.react-theme-toggle {
 }
 
 .morphing-text.morphing-text--ready {
-  filter: none;
+  filter: url(#morphing-text-threshold) blur(0.6px);
 }
 
 .morphing-text__filter {


### PR DESCRIPTION
## Summary

- Applies `filter: url(#morphing-text-threshold) blur(0.6px)` to the morphing-text container when the animation is active, matching the [Magic UI reference implementation](https://magicui.design/docs/components/morphing-text)
- The `feColorMatrix` threshold filter combined with per-span blur creates the signature **liquid merge** effect — texts flow into each other rather than a plain opacity crossfade
- The SVG filter only modifies the alpha channel (RGB pass-through), so gradient colors are fully preserved

## Test plan

- [ ] Visit the hero section on the preview deployment
- [ ] Confirm role titles visually "morph" into each other with a liquid/gooey merge (not just a fade)
- [ ] Confirm gradient colours remain visible throughout the transition
- [ ] Confirm reduced-motion users see static text (no filter applied, no animation)

https://claude.ai/code/session_01SdqWgAfBVRR2xwUtfcz9Nv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdqWgAfBVRR2xwUtfcz9Nv)_